### PR TITLE
fix: edit README.md because markdown content break

### DIFF
--- a/AWS-GenAI-Code-Security-Review/README.md
+++ b/AWS-GenAI-Code-Security-Review/README.md
@@ -51,15 +51,16 @@ Ensure the following output format:
 - Description: <output>
 - ###### Severity: <output>
 - ###### A snippet of affected code:
-```
-<output>
-```
+    ```
+    <output>
+    ```
 - ###### Mitigation walkthrough:
 <output>
+
 - ###### Improved code:
-```
-<output>
-```
+    ```
+    <output>
+    ```
 ---
 
 Focus on clarity and detail to ensure that your analysis is thorough and understandable."


### PR DESCRIPTION
*Issue: fix `README.md` document*

*Description of changes:*
- update README.md
The ``` character in description for .env can't display well, I added indent behind it to fix that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
