### PR TITLE
fix: resolve high severity CVEs in granian, python-multipart, and Git…

### DIFF
--- a/AWS-AI-Powered-Translation-Assistant/Text.py
+++ b/AWS-AI-Powered-Translation-Assistant/Text.py
@@ -36,7 +36,7 @@ models = lst_models()
 st.sidebar.selectbox(
     label='Model',
     options=models,
-    index=models.index(next(filter(lambda n: n.get('modelId') == 'anthropic.claude-3-haiku-20240307-v1:0', models))),
+    index=models.index(next(filter(lambda n: n.get('modelId') == 'amazon.nova-2-lite-v1:0', models))),
     format_func=lambda model: model['modelId'].split(".")[1],
     key='model'
 )

--- a/AWS-AI-Powered-Translation-Assistant/pages/Chat.py
+++ b/AWS-AI-Powered-Translation-Assistant/pages/Chat.py
@@ -27,7 +27,7 @@ models = lst_models()
 st.sidebar.selectbox(
     label='Model',
     options=models,
-    index=models.index(next(filter(lambda n: n.get('modelId') == 'anthropic.claude-3-haiku-20240307-v1:0', models))),
+    index=models.index(next(filter(lambda n: n.get('modelId') == 'amazon.nova-2-lite-v1:0', models))),
     format_func=lambda model: model['modelId'].split(".")[1],
     key='model'
 )

--- a/AWS-AI-Powered-Translation-Assistant/pages/File.py
+++ b/AWS-AI-Powered-Translation-Assistant/pages/File.py
@@ -35,7 +35,7 @@ models = lst_models()
 st.sidebar.selectbox(
     label='Model',
     options=models,
-    index=models.index(next(filter(lambda n: n.get('modelId') == 'anthropic.claude-3-haiku-20240307-v1:0', models))),
+    index=models.index(next(filter(lambda n: n.get('modelId') == 'amazon.nova-2-lite-v1:0', models))),
     format_func=lambda model: model['modelId'].split(".")[1],
     key='model'
 )

--- a/AWS-Educational-Assistant/Libs.py
+++ b/AWS-Educational-Assistant/Libs.py
@@ -29,7 +29,7 @@ def call_claude_sonet_stream(prompt):
 
     body = json.dumps(prompt_config)
 
-    modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
     accept = "application/json"
     contentType = "application/json"
 
@@ -232,7 +232,7 @@ def search(question, callback):
     
     # Initialize the BedrockChat LLM with streaming enabled
     llm = BedrockChat(
-        model_id="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        model_id="anthropic.claude-sonnet-4-6",
         model_kwargs=model_kwargs_claude,
         streaming=True,
         callbacks=[callback]

--- a/AWS-Educational-Assistant/requirements.txt
+++ b/AWS-Educational-Assistant/requirements.txt
@@ -1,5 +1,5 @@
 transformers
-Pillow
+Pillow>=12.1.0
 pypdf
 jq
 langchain

--- a/AWS-First-Cloud-Journey-Uniform-Detection/Libs.py
+++ b/AWS-First-Cloud-Journey-Uniform-Detection/Libs.py
@@ -31,7 +31,7 @@ def call_claude_sonet_stream(prompt):
 
     body = json.dumps(prompt_config)
 
-    modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
     accept = "application/json"
     contentType = "application/json"
 
@@ -112,7 +112,7 @@ def get_response_from_model(prompt_content, image_bytes):
     session = boto3.Session()
     bedrock = session.client(service_name='bedrock-runtime') #creates a Bedrock client
     body = init(prompt_content, image_bytes)    
-    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0", contentType="application/json", accept="application/json")
+    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-sonnet-4-6", contentType="application/json", accept="application/json")
         
     stream = response['body']
     if stream:

--- a/AWS-First-Cloud-Journey-Uniform-Detection/check_in/check_in_lib.py
+++ b/AWS-First-Cloud-Journey-Uniform-Detection/check_in/check_in_lib.py
@@ -151,7 +151,7 @@ def get_response_from_model(prompt_content=None, image_bytes=None, mask_prompt=N
     
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/AWS-First-Cloud-Journey-Uniform-Detection/check_uniform/check_uniform_lib.py
+++ b/AWS-First-Cloud-Journey-Uniform-Detection/check_uniform/check_uniform_lib.py
@@ -99,7 +99,7 @@ def get_response_from_model(image_bytes):
     
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/AWS-First-Cloud-Journey-Uniform-Detection/content_moderation.1/content_moderation_lib.py
+++ b/AWS-First-Cloud-Journey-Uniform-Detection/content_moderation.1/content_moderation_lib.py
@@ -84,7 +84,7 @@ def get_response_from_model(prompt_content, image_bytes):
     body = get_content_moderation_prompt(image_bytes)    
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/AWS-First-Cloud-Journey-Uniform-Detection/content_moderation/content_moderation_lib.py
+++ b/AWS-First-Cloud-Journey-Uniform-Detection/content_moderation/content_moderation_lib.py
@@ -175,7 +175,7 @@ def analyze_frame(session, frame):
         body = get_content_moderation_prompt(frame)
         response = session.invoke_model_with_response_stream(
             body=body,
-            modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            modelId="anthropic.claude-sonnet-4-6",
             contentType="application/json",
             accept="application/json"
         )
@@ -228,7 +228,7 @@ def get_response_from_model(prompt_content, content_bytes, content_type="image")
             
             response = bedrock.invoke_model_with_response_stream(
                 body=body,
-                modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                modelId="anthropic.claude-sonnet-4-6",
                 contentType="application/json",
                 accept="application/json"
             )

--- a/AWS-First-Cloud-Journey-Uniform-Detection/image_lib.py
+++ b/AWS-First-Cloud-Journey-Uniform-Detection/image_lib.py
@@ -15,7 +15,7 @@ bedrock = session.client(
     endpoint_url=os.environ.get("BWB_ENDPOINT_URL")
 ) 
 
-bedrock_model_id = "stability.stable-diffusion-xl-v1" #use the Stable Diffusion model
+bedrock_model_id = "amazon.nova-canvas-v1:0" #use the Stable Diffusion model
 
 
 

--- a/AWS-First-Cloud-Journey-Uniform-Detection/product_description/product_description_lib.py
+++ b/AWS-First-Cloud-Journey-Uniform-Detection/product_description/product_description_lib.py
@@ -113,7 +113,7 @@ def get_response_from_model(prompt_content, image_bytes, prizm):
     body = get_product_description(prompt_content, image_bytes, prizm)    
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/AWS-First-Cloud-Journey-Uniform-Detection/requirements.txt
+++ b/AWS-First-Cloud-Journey-Uniform-Detection/requirements.txt
@@ -10,7 +10,7 @@ torch
 
 # Image and Video Processing
 opencv-python-headless
-Pillow
+Pillow>=12.1.0
 numpy
 
 # Document processing

--- a/AWS-GenAI-Code-Security-Review/app.py
+++ b/AWS-GenAI-Code-Security-Review/app.py
@@ -1,8 +1,15 @@
 import streamlit as st
 import os
+import re
 from code_review.git_handler import analyze_repository, output_messages
 from code_review.bedrock_analyze import analyze_file_contents
 import chardet
+
+def _sanitize_name(name):
+    """Sanitize a name to prevent path traversal."""
+    sanitized = re.sub(r'[^a-zA-Z0-9._-]', '_', name)
+    sanitized = sanitized.replace('..', '').lstrip('.')
+    return sanitized or 'unnamed'
 
 def analyze_uploaded_file(uploaded_file):
     try:

--- a/AWS-GenAI-Code-Security-Review/code_review/git_handler.py
+++ b/AWS-GenAI-Code-Security-Review/code_review/git_handler.py
@@ -1,4 +1,5 @@
 import git
+import re
 import os
 import sys
 import datetime
@@ -25,6 +26,16 @@ BLACKLIST = [
 
 output_messages = []
 
+def _sanitize_name(name):
+    """Sanitize a name to prevent path traversal. Only allow alphanumeric, hyphens, underscores, and dots."""
+    sanitized = re.sub(r'[^a-zA-Z0-9._-]', '_', name)
+    # Remove path traversal sequences and leading dots
+    sanitized = sanitized.replace('..', '')
+    sanitized = sanitized.lstrip('.')
+    if not sanitized:
+        sanitized = 'unnamed'
+    return sanitized
+
 def clear_report_directory():
     """Clear the 'report' directory before running analysis."""
     report_path = f"{os.getcwd()}/report"
@@ -35,8 +46,8 @@ def clear_report_directory():
 def analyze_repository(repo_url):
     clear_report_directory() 
     
-    repo_name = repo_url.split("/")[-1].replace(".git", "")
-    local_repo_path = f"source/{repo_name}"
+    repo_name = _sanitize_name(repo_url.split("/")[-1].replace(".git", ""))
+    local_repo_path = os.path.join("source", repo_name)
 
     if os.path.isdir(local_repo_path):
         repo = git.Repo(local_repo_path)

--- a/AWS-GenAI-Code-Security-Review/requirements.txt
+++ b/AWS-GenAI-Code-Security-Review/requirements.txt
@@ -5,13 +5,13 @@ async-timeout==4.0.3
 attrs==23.1.0
 blinker==1.6.3
 cachetools==5.3.1
-certifi==2023.7.22
+certifi==2024.7.4
 chardet==5.2.0
 charset-normalizer==3.3.0
 click==8.1.7
 frozenlist==1.4.0
 gitdb==4.0.11
-GitPython==3.1.40
+GitPython==3.1.43
 idna==3.4
 importlib-metadata==6.8.0
 Jinja2==3.1.2
@@ -25,7 +25,7 @@ numpy==1.26.1
 openai==0.28.1
 packaging==23.2
 pandas==2.1.1
-Pillow==10.1.0
+Pillow==12.1.0
 protobuf==4.24.4
 pyarrow==18.0.0
 pydeck==0.8.1b0
@@ -34,7 +34,7 @@ python-dateutil==2.8.2
 python-dotenv==1.0.0
 pytz==2023.3.post1
 referencing==0.30.2
-requests==2.31.0
+requests==2.33.0
 rich==13.6.0
 rpds-py==0.10.6
 six==1.16.0
@@ -48,11 +48,10 @@ tqdm==4.66.3
 typing_extensions==4.8.0
 tzdata==2023.3
 tzlocal==5.2
-urllib3==2.2.2
+urllib3==2.6.3
 validators==0.22.0
 watchdog==3.0.0
 yarl==1.17.1
 zipp==3.21.0
 boto3==1.35.58
 botocore==1.35.58
-GitPython==3.1.40

--- a/AWS-GenAI-Market-Sage/libs.py
+++ b/AWS-GenAI-Market-Sage/libs.py
@@ -25,7 +25,7 @@ def call_claude_sonet_stream(prompt):
         ],
     }
 
-    modelId = "anthropic.claude-3-sonnet-20240229-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
 
     bedrock = boto3.client(service_name="bedrock-runtime")  
     response = bedrock.invoke_model_with_response_stream(
@@ -136,7 +136,7 @@ def search(question, callback):
 
     model_kwargs_claude = { "temperature": 0.5, "top_p": 1}
     llm = BedrockChat(
-        model_id="anthropic.claude-3-sonnet-20240229-v1:0",  # Updated model ID
+        model_id="anthropic.claude-sonnet-4-6",  # Updated model ID
         client=bedrock_client,
         model_kwargs=model_kwargs_claude,
         streaming=True,
@@ -186,7 +186,7 @@ def searchOld(question, callback):
     Answer: 
     """
     model_kwargs_claude = {"max_tokens": 2000}
-    llm = BedrockChat(model_id="anthropic.claude-3-5-sonnet-20240620-v1:0"
+    llm = BedrockChat(model_id="anthropic.claude-sonnet-4-6"
                       , model_kwargs=model_kwargs_claude
                       , streaming=True
                       , callbacks=[callback])

--- a/AWS-GenAI-Market-Sage/pages/stock_advisor.py
+++ b/AWS-GenAI-Market-Sage/pages/stock_advisor.py
@@ -10,7 +10,7 @@ anthropic = Anthropic()
 
 # Knowledge base and model configuration
 knowledge_base_id = ('F3BT8DD8E8'),  # Previously EWVHJIY9AS
-modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"  # Previously claude-3-haiku model
+modelId = "anthropic.claude-sonnet-4-6"  # Previously claude-3-haiku model
 
 # Streamlit page configuration
 st.set_page_config(

--- a/AWS-GenAI-Market-Sage/pages/stock_agent.py
+++ b/AWS-GenAI-Market-Sage/pages/stock_agent.py
@@ -44,7 +44,7 @@ base.init_animation()
 anthropic = Anthropic()
 knowledge_base_id=("EWVHJIY9AS")
 
-modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+modelId = "anthropic.claude-sonnet-4-6"
     
 def get_llm():      
     # Configure the model to use

--- a/AWS-GenAI-Market-Sage/pages/stock_analytics.py
+++ b/AWS-GenAI-Market-Sage/pages/stock_analytics.py
@@ -75,7 +75,7 @@ def call_claude_sonet_stream(prompt):
 
     body = json.dumps(prompt_config)
 
-    modelId = "anthropic.claude-3-sonnet-20240229-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
     accept = "application/json"
     contentType = "application/json"
 

--- a/AWS-OCR-with-Amazon-Bedrock/claude3_boto3_ocr.py
+++ b/AWS-OCR-with-Amazon-Bedrock/claude3_boto3_ocr.py
@@ -9,7 +9,7 @@ import os
 import boto3
 
 
-MODEL_ID = os.environ.get('MODEL_ID', 'anthropic.claude-3-5-sonnet-20240620-v1:0')
+MODEL_ID = os.environ.get('MODEL_ID', 'anthropic.claude-sonnet-4-6')
 
 
 def build_chain():

--- a/AWS-OCR-with-Amazon-Bedrock/claude3_langchain_ocr.py
+++ b/AWS-OCR-with-Amazon-Bedrock/claude3_langchain_ocr.py
@@ -13,7 +13,7 @@ from langchain_core.outputs import ChatGenerationChunk
 class ClaudeOCRProcessor:
     """Handles OCR processing using Claude 3.5 Sonnet"""
     
-    DEFAULT_MODEL = 'anthropic.claude-3-sonnet-20240229-v1:0'
+    DEFAULT_MODEL = 'anthropic.claude-sonnet-4-6'
     
     def __init__(
         self,

--- a/AWS-Stock-Agent-with-Bedrock/libs.py
+++ b/AWS-Stock-Agent-with-Bedrock/libs.py
@@ -25,7 +25,7 @@ def call_claude_sonet_stream(prompt):
         ],
     }
 
-    modelId = "anthropic.claude-3-sonnet-20240229-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
 
     bedrock = boto3.client(service_name="bedrock-runtime")  
     response = bedrock.invoke_model_with_response_stream(
@@ -136,7 +136,7 @@ def search(question, callback):
 
     model_kwargs_claude = { "temperature": 0.5, "top_p": 1}
     llm = BedrockChat(
-        model_id="anthropic.claude-3-sonnet-20240229-v1:0",  # Updated model ID
+        model_id="anthropic.claude-sonnet-4-6",  # Updated model ID
         client=bedrock_client,
         model_kwargs=model_kwargs_claude,
         streaming=True,
@@ -186,7 +186,7 @@ def searchOld(question, callback):
     Answer: 
     """
     model_kwargs_claude = {"max_tokens": 2000}
-    llm = BedrockChat(model_id="anthropic.claude-3-5-sonnet-20240620-v1:0"
+    llm = BedrockChat(model_id="anthropic.claude-sonnet-4-6"
                       , model_kwargs=model_kwargs_claude
                       , streaming=True
                       , callbacks=[callback])

--- a/AWS-Stock-Agent-with-Bedrock/pages/stock_advisor.py
+++ b/AWS-Stock-Agent-with-Bedrock/pages/stock_advisor.py
@@ -10,8 +10,8 @@ anthropic = Anthropic()
 
 #knowledge_base_id=('EWVHJIY9AS'),
 knowledge_base_id=('GDPSQICWNW'),
-#modelId = "anthropic.claude-3-haiku-20240307-v1:0"
-modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+#modelId = "amazon.nova-2-lite-v1:0"
+modelId = "anthropic.claude-sonnet-4-6"
 
 st.set_page_config(page_title="Tra cứu thông tin chứng khoán", page_icon="img/favicon.ico", layout="wide")
 st.markdown(

--- a/AWS-Stock-Agent-with-Bedrock/pages/stock_agent.py
+++ b/AWS-Stock-Agent-with-Bedrock/pages/stock_agent.py
@@ -44,7 +44,7 @@ base.init_animation()
 anthropic = Anthropic()
 knowledge_base_id=("EWVHJIY9AS")
 
-modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+modelId = "anthropic.claude-sonnet-4-6"
     
 def get_llm():      
     # Configure the model to use

--- a/AWS-Stock-Agent-with-Bedrock/pages/stock_analytics.py
+++ b/AWS-Stock-Agent-with-Bedrock/pages/stock_analytics.py
@@ -74,7 +74,7 @@ def call_claude_sonet_stream(prompt):
 
     body = json.dumps(prompt_config)
 
-    modelId = "anthropic.claude-3-sonnet-20240229-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
     accept = "application/json"
     contentType = "application/json"
 

--- a/Amazon-Bedrock-Alt-Text-Generator/pdf_image_alt_text_generator/generator.py
+++ b/Amazon-Bedrock-Alt-Text-Generator/pdf_image_alt_text_generator/generator.py
@@ -22,7 +22,7 @@ logger.setLevel(logging.INFO)
 
 session = boto3.Session(region_name="us-east-1")
 
-MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0"
+MODEL_ID = "amazon.nova-2-lite-v1:0"
 
 
 class ModelOutput(BaseModel):

--- a/Amazon-Bedrock-Alt-Text-Generator/requirements.txt
+++ b/Amazon-Bedrock-Alt-Text-Generator/requirements.txt
@@ -2,6 +2,6 @@ langchain>=0.3.0,<0.4.0
 langchain-community==0.3.0
 pypdf==4.3.1
 streamlit==1.37.1
-pillow==10.4.0
+pillow==12.1.0
 pymupdf==1.24.9
 reportlab==4.2.2

--- a/Amazon-Bedrock-Claude3-Image-Analysis/analyze_images.py
+++ b/Amazon-Bedrock-Claude3-Image-Analysis/analyze_images.py
@@ -86,7 +86,7 @@ def analyze_image(image_name, text) -> str:
     # formatting the prompt as a json string
     json_prompt = json.dumps(prompt)
     # invoking Claude3, passing in our prompt
-    response = bedrock.invoke_model(body=json_prompt, modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+    response = bedrock.invoke_model(body=json_prompt, modelId="anthropic.claude-sonnet-4-6",
                                     accept="application/json", contentType="application/json")
     # getting the response from Claude3 and parsing it to return to the end user
     response_body = json.loads(response.get('body').read())

--- a/Amazon-Bedrock-Claude3-Image-Analysis/requirements.txt
+++ b/Amazon-Bedrock-Claude3-Image-Analysis/requirements.txt
@@ -8,7 +8,7 @@ certifi==2024.7.4
 charset-normalizer==3.3.2
 click==8.1.7
 gitdb==4.0.11
-GitPython==3.1.42
+GitPython==3.1.43
 idna==3.7
 importlib-metadata==7.0.1
 Jinja2==3.1.4
@@ -21,7 +21,7 @@ mdurl==0.1.2
 numpy==1.26.4
 packaging==23.2
 pandas==2.2.1
-pillow==10.2.0
+pillow==12.1.0
 pip==23.3
 protobuf==4.25.3
 pyarrow==15.0.0
@@ -31,7 +31,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 pytz==2024.1
 referencing==0.33.0
-requests==2.32.2
+requests==2.33.0
 rich==13.7.1
 rpds-py==0.18.0
 s3transfer==0.10.0
@@ -46,7 +46,7 @@ tornado==6.4.2
 typing_extensions==4.10.0
 tzdata==2024.1
 tzlocal==5.2
-urllib3==1.26.19
+urllib3==2.6.3
 validators==0.22.0
 wheel==0.41.2
 zipp==3.19.1

--- a/Amazon-Bedrock-Model-Evaluator/evaluation_steps.py
+++ b/Amazon-Bedrock-Model-Evaluator/evaluation_steps.py
@@ -73,7 +73,7 @@ async def model_execution(client, user_prompt, system_prompt):
     # Invoke the model asynchronously with the provided prompt
     response = await client.invoke_model(
         body=prompt,
-        modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         accept="application/json",
         contentType="application/json"
     )
@@ -952,7 +952,7 @@ This is the prompt/instructions that the models will be provided and that you wi
     # create Bedrock client
     client = boto3.client('bedrock-runtime', region)
     # Invoking the Amazon Bedrock and the Claude 3 Sonnet model with the constructed prompt
-    response = client.invoke_model(body=prompt, modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+    response = client.invoke_model(body=prompt, modelId="anthropic.claude-sonnet-4-6",
                                    accept="application/json", contentType="application/json")
     # Extracting and parsing the response from the AI model
     response_body = json.loads(response.get('body').read())
@@ -1068,12 +1068,12 @@ Summary: {model_task_summary}
     # Return the final score, final summary, and final scoring rubric
     return final_score, final_summary, final_score_rubric
 
-def evaluate_model_performance(csv_string, model_id="anthropic.claude-3-sonnet-20240229-v1:0"):
+def evaluate_model_performance(csv_string, model_id="anthropic.claude-sonnet-4-6"):
     """
     Evaluates the performance of AI models based on provided CSV data.
 
     :param csv_string: A string containing CSV data with columns for 'Total Cost(1000)', 'Time Length', and 'Summary Score'.
-    :param model_id: The ID of the model used for evaluation. Defaults to "anthropic.claude-3-sonnet-20240229-v1:0".
+    :param model_id: The ID of the model used for evaluation. Defaults to "anthropic.claude-sonnet-4-6".
     :return: A string containing the analysis and findings of model performance based on the provided CSV data.
     """
     # Constructing a prompt for the Amazon Bedrock Claude 3 Sonnet model to analyze the provided CSV data
@@ -1133,12 +1133,12 @@ def evaluate_model_performance(csv_string, model_id="anthropic.claude-3-sonnet-2
     # Returns a string containing the analysis and findings of model performance based on the provided CSV data.
     return response
 
-def evaluate_rag_performance(csv_string, model_id="anthropic.claude-3-sonnet-20240229-v1:0"):
+def evaluate_rag_performance(csv_string, model_id="anthropic.claude-sonnet-4-6"):
     """
     Evaluates the performance of AI models based on provided CSV data.
 
     :param csv_string: A string containing CSV data with columns for 'Total Cost(1000)', 'Time Length', and 'Summary Score'.
-    :param model_id: The ID of the model used for evaluation. Defaults to "anthropic.claude-3-sonnet-20240229-v1:0".
+    :param model_id: The ID of the model used for evaluation. Defaults to "anthropic.claude-sonnet-4-6".
     :return: A string containing the analysis and findings of model performance based on the provided CSV data.
     """
     # Constructing a prompt for the Amazon Bedrock Claude 3 Sonnet model to analyze the provided CSV data

--- a/Amazon-Bedrock-Model-Evaluator/orchestrator.py
+++ b/Amazon-Bedrock-Model-Evaluator/orchestrator.py
@@ -57,8 +57,8 @@ bedrock_runtime = boto3.client(
 )
 
 
-llm_for_text_generation = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0", client=bedrock_runtime) ##TODO update to allow user to select the model they want to use
-llm_for_evaluation = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0", client=bedrock_runtime)
+llm_for_text_generation = ChatBedrock(model_id="anthropic.claude-sonnet-4-6", client=bedrock_runtime) ##TODO update to allow user to select the model they want to use
+llm_for_evaluation = ChatBedrock(model_id="anthropic.claude-sonnet-4-6", client=bedrock_runtime)
 
 metrics = [
         faithfulness,
@@ -330,7 +330,7 @@ def final_evaluator(pdf_path, models, task_prompt="Summarize this document in 2 
     # Read CSV data from StringIO object (as a string)
     csv_string = csv_data.getvalue()
     # ask the model which is the best model to use for cost and performance
-    invoke_costs_eval_response = evaluate_model_performance(csv_string, "anthropic.claude-3-sonnet-20240229-v1:0")
+    invoke_costs_eval_response = evaluate_model_performance(csv_string, "anthropic.claude-sonnet-4-6")
     # chart out the performance and cost results
     plot_model_comparisons(results_df)
     # plot the performance rubric scores 
@@ -465,7 +465,7 @@ def final_rag_evaluator(csv_path_1, csv_path_2, knowledge_bases):
     # Read CSV data from StringIO object (as a string)
     csv_string = csv_data.getvalue()
     # ask the model which is the best model to use for cost and performance
-    invoke_costs_eval_response = evaluate_rag_performance(csv_string, "anthropic.claude-3-sonnet-20240229-v1:0")
+    invoke_costs_eval_response = evaluate_rag_performance(csv_string, "anthropic.claude-sonnet-4-6")
     # chart out the performance and cost results
     plot_rag_comparisons(results_df)
     # plot the performance rubric scores 

--- a/Amazon-Bedrock-Model-Evaluator/requirements.txt
+++ b/Amazon-Bedrock-Model-Evaluator/requirements.txt
@@ -22,7 +22,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 contourpy==1.2.1
-cryptography==42.0.5
+cryptography==46.0.5
 cycler==0.12.1
 dataclasses-json==0.6.7
 datasets==2.19.2
@@ -77,7 +77,7 @@ orjson==3.10.5
 packaging==24.0
 palettable==3.3.3
 pandas==2.2.1
-pillow==10.3.0
+pillow==12.1.0
 pip==23.3
 prometheus_client==0.20.0
 protobuf==4.25.3
@@ -99,7 +99,7 @@ PyYAML==6.0.1
 ragas==0.1.9
 referencing==0.34.0
 regex==2024.5.15
-requests==2.32.3
+requests==2.33.0
 rich==13.7.1
 rpds-py==0.18.0
 s3transfer==0.10.1
@@ -129,7 +129,7 @@ tqdm==4.66.4
 typing-inspect==0.9.0
 typing_extensions==4.11.0
 tzdata==2024.1
-urllib3==2.2.2
+urllib3==2.6.3
 validators==0.28.0
 wheel==0.41.2
 wrapt==1.16.0

--- a/CV-Maestro-Elevate-Your-Career-Narrative-with-Amazon-Bedrock/pages/1_Read_Resume.py
+++ b/CV-Maestro-Elevate-Your-Career-Narrative-with-Amazon-Bedrock/pages/1_Read_Resume.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 import json
 
 # Constants and configurations
-CLAUDE_MODEL = "anthropic.claude-3-sonnet-20240229-v1:0"
+CLAUDE_MODEL = "anthropic.claude-sonnet-4-6"
 
 class BedrockClient:
     def __init__(self):

--- a/CV-Maestro-Elevate-Your-Career-Narrative-with-Amazon-Bedrock/requirements.txt
+++ b/CV-Maestro-Elevate-Your-Career-Narrative-with-Amazon-Bedrock/requirements.txt
@@ -1,5 +1,5 @@
 transformers
-Pillow
+Pillow>=12.1.0
 pypdf
 jq
 langchain==0.3.0

--- a/Content-Moderation-with-Amazon-Bedrock/Libs.py
+++ b/Content-Moderation-with-Amazon-Bedrock/Libs.py
@@ -31,7 +31,7 @@ def call_claude_sonet_stream(prompt):
 
     body = json.dumps(prompt_config)
 
-    modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
     accept = "application/json"
     contentType = "application/json"
 
@@ -112,7 +112,7 @@ def get_response_from_model(prompt_content, image_bytes):
     session = boto3.Session()
     bedrock = session.client(service_name='bedrock-runtime') #creates a Bedrock client
     body = init(prompt_content, image_bytes)    
-    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0", contentType="application/json", accept="application/json")
+    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-sonnet-4-6", contentType="application/json", accept="application/json")
         
     stream = response['body']
     if stream:

--- a/Content-Moderation-with-Amazon-Bedrock/check_in/check_in_lib.py
+++ b/Content-Moderation-with-Amazon-Bedrock/check_in/check_in_lib.py
@@ -151,7 +151,7 @@ def get_response_from_model(prompt_content=None, image_bytes=None, mask_prompt=N
     
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Content-Moderation-with-Amazon-Bedrock/check_uniform/check_uniform_lib.py
+++ b/Content-Moderation-with-Amazon-Bedrock/check_uniform/check_uniform_lib.py
@@ -99,7 +99,7 @@ def get_response_from_model(image_bytes):
     
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Content-Moderation-with-Amazon-Bedrock/content_moderation.1/content_moderation_lib.py
+++ b/Content-Moderation-with-Amazon-Bedrock/content_moderation.1/content_moderation_lib.py
@@ -84,7 +84,7 @@ def get_response_from_model(prompt_content, image_bytes):
     body = get_content_moderation_prompt(image_bytes)    
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Content-Moderation-with-Amazon-Bedrock/content_moderation/content_moderation_lib.py
+++ b/Content-Moderation-with-Amazon-Bedrock/content_moderation/content_moderation_lib.py
@@ -175,7 +175,7 @@ def analyze_frame(session, frame):
         body = get_content_moderation_prompt(frame)
         response = session.invoke_model_with_response_stream(
             body=body,
-            modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            modelId="anthropic.claude-sonnet-4-6",
             contentType="application/json",
             accept="application/json"
         )
@@ -228,7 +228,7 @@ def get_response_from_model(prompt_content, content_bytes, content_type="image")
             
             response = bedrock.invoke_model_with_response_stream(
                 body=body,
-                modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                modelId="anthropic.claude-sonnet-4-6",
                 contentType="application/json",
                 accept="application/json"
             )

--- a/Content-Moderation-with-Amazon-Bedrock/image_lib.py
+++ b/Content-Moderation-with-Amazon-Bedrock/image_lib.py
@@ -15,7 +15,7 @@ bedrock = session.client(
     endpoint_url=os.environ.get("BWB_ENDPOINT_URL")
 ) 
 
-bedrock_model_id = "stability.stable-diffusion-xl-v1" #use the Stable Diffusion model
+bedrock_model_id = "amazon.nova-canvas-v1:0" #use the Stable Diffusion model
 
 
 

--- a/Content-Moderation-with-Amazon-Bedrock/product_description/product_description_lib.py
+++ b/Content-Moderation-with-Amazon-Bedrock/product_description/product_description_lib.py
@@ -113,7 +113,7 @@ def get_response_from_model(prompt_content, image_bytes, prizm):
     body = get_product_description(prompt_content, image_bytes, prizm)    
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Content-Moderation-with-Amazon-Bedrock/requirements.txt
+++ b/Content-Moderation-with-Amazon-Bedrock/requirements.txt
@@ -10,7 +10,7 @@ torch
 
 # Image and Video Processing
 opencv-python-headless
-Pillow
+Pillow>=12.1.0
 numpy
 
 # Document processing

--- a/GenAI-Model-Evaluator/evaluation_steps.py
+++ b/GenAI-Model-Evaluator/evaluation_steps.py
@@ -73,7 +73,7 @@ async def model_execution(client, user_prompt, system_prompt):
     # Invoke the model asynchronously with the provided prompt
     response = await client.invoke_model(
         body=prompt,
-        modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         accept="application/json",
         contentType="application/json"
     )
@@ -952,7 +952,7 @@ This is the prompt/instructions that the models will be provided and that you wi
     # create Bedrock client
     client = boto3.client('bedrock-runtime', region)
     # Invoking the Amazon Bedrock and the Claude 3 Sonnet model with the constructed prompt
-    response = client.invoke_model(body=prompt, modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+    response = client.invoke_model(body=prompt, modelId="anthropic.claude-sonnet-4-6",
                                    accept="application/json", contentType="application/json")
     # Extracting and parsing the response from the AI model
     response_body = json.loads(response.get('body').read())
@@ -1068,12 +1068,12 @@ Summary: {model_task_summary}
     # Return the final score, final summary, and final scoring rubric
     return final_score, final_summary, final_score_rubric
 
-def evaluate_model_performance(csv_string, model_id="anthropic.claude-3-sonnet-20240229-v1:0"):
+def evaluate_model_performance(csv_string, model_id="anthropic.claude-sonnet-4-6"):
     """
     Evaluates the performance of AI models based on provided CSV data.
 
     :param csv_string: A string containing CSV data with columns for 'Total Cost(1000)', 'Time Length', and 'Summary Score'.
-    :param model_id: The ID of the model used for evaluation. Defaults to "anthropic.claude-3-sonnet-20240229-v1:0".
+    :param model_id: The ID of the model used for evaluation. Defaults to "anthropic.claude-sonnet-4-6".
     :return: A string containing the analysis and findings of model performance based on the provided CSV data.
     """
     # Constructing a prompt for the Amazon Bedrock Claude 3 Sonnet model to analyze the provided CSV data
@@ -1133,12 +1133,12 @@ def evaluate_model_performance(csv_string, model_id="anthropic.claude-3-sonnet-2
     # Returns a string containing the analysis and findings of model performance based on the provided CSV data.
     return response
 
-def evaluate_rag_performance(csv_string, model_id="anthropic.claude-3-sonnet-20240229-v1:0"):
+def evaluate_rag_performance(csv_string, model_id="anthropic.claude-sonnet-4-6"):
     """
     Evaluates the performance of AI models based on provided CSV data.
 
     :param csv_string: A string containing CSV data with columns for 'Total Cost(1000)', 'Time Length', and 'Summary Score'.
-    :param model_id: The ID of the model used for evaluation. Defaults to "anthropic.claude-3-sonnet-20240229-v1:0".
+    :param model_id: The ID of the model used for evaluation. Defaults to "anthropic.claude-sonnet-4-6".
     :return: A string containing the analysis and findings of model performance based on the provided CSV data.
     """
     # Constructing a prompt for the Amazon Bedrock Claude 3 Sonnet model to analyze the provided CSV data

--- a/GenAI-Model-Evaluator/orchestrator.py
+++ b/GenAI-Model-Evaluator/orchestrator.py
@@ -57,8 +57,8 @@ bedrock_runtime = boto3.client(
 )
 
 
-llm_for_text_generation = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0", client=bedrock_runtime) ##TODO update to allow user to select the model they want to use
-llm_for_evaluation = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0", client=bedrock_runtime)
+llm_for_text_generation = ChatBedrock(model_id="anthropic.claude-sonnet-4-6", client=bedrock_runtime) ##TODO update to allow user to select the model they want to use
+llm_for_evaluation = ChatBedrock(model_id="anthropic.claude-sonnet-4-6", client=bedrock_runtime)
 
 metrics = [
         faithfulness,
@@ -330,7 +330,7 @@ def final_evaluator(pdf_path, models, task_prompt="Summarize this document in 2 
     # Read CSV data from StringIO object (as a string)
     csv_string = csv_data.getvalue()
     # ask the model which is the best model to use for cost and performance
-    invoke_costs_eval_response = evaluate_model_performance(csv_string, "anthropic.claude-3-sonnet-20240229-v1:0")
+    invoke_costs_eval_response = evaluate_model_performance(csv_string, "anthropic.claude-sonnet-4-6")
     # chart out the performance and cost results
     plot_model_comparisons(results_df)
     # plot the performance rubric scores 
@@ -465,7 +465,7 @@ def final_rag_evaluator(csv_path_1, csv_path_2, knowledge_bases):
     # Read CSV data from StringIO object (as a string)
     csv_string = csv_data.getvalue()
     # ask the model which is the best model to use for cost and performance
-    invoke_costs_eval_response = evaluate_rag_performance(csv_string, "anthropic.claude-3-sonnet-20240229-v1:0")
+    invoke_costs_eval_response = evaluate_rag_performance(csv_string, "anthropic.claude-sonnet-4-6")
     # chart out the performance and cost results
     plot_rag_comparisons(results_df)
     # plot the performance rubric scores 

--- a/GenAI-Model-Evaluator/requirements.txt
+++ b/GenAI-Model-Evaluator/requirements.txt
@@ -22,7 +22,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 contourpy==1.2.1
-cryptography==42.0.5
+cryptography==46.0.5
 cycler==0.12.1
 dataclasses-json==0.6.7
 datasets==2.19.2
@@ -77,7 +77,7 @@ orjson==3.10.5
 packaging==24.0
 palettable==3.3.3
 pandas==2.2.1
-pillow==10.3.0
+pillow==12.1.0
 pip==23.3
 prometheus_client==0.20.0
 protobuf==4.25.3
@@ -99,7 +99,7 @@ PyYAML==6.0.1
 ragas==0.1.9
 referencing==0.34.0
 regex==2024.5.15
-requests==2.32.3
+requests==2.33.0
 rich==13.7.1
 rpds-py==0.18.0
 s3transfer==0.10.1
@@ -129,7 +129,7 @@ tqdm==4.66.4
 typing-inspect==0.9.0
 typing_extensions==4.11.0
 tzdata==2024.1
-urllib3==2.2.2
+urllib3==2.6.3
 validators==0.28.0
 wheel==0.41.2
 wrapt==1.16.0

--- a/Generate-images-using-Amazon-Bedrock-with-stability-diffusion-model/prompt/app-prompt.py
+++ b/Generate-images-using-Amazon-Bedrock-with-stability-diffusion-model/prompt/app-prompt.py
@@ -6,7 +6,7 @@ from botocore.exceptions import ClientError
 client = boto3.client("bedrock-runtime", region_name="us-west-2")
 
 # Define Claude 3 Sonnet model ID
-model_id = "anthropic.claude-3-sonnet-20240229-v1:0"
+model_id = "anthropic.claude-sonnet-4-6"
 
 # Function to call AWS Bedrock with user input
 def generate_prompts(user_topic):

--- a/Generate-images-using-Amazon-Bedrock-with-stability-diffusion-model/requirements.txt
+++ b/Generate-images-using-Amazon-Bedrock-with-stability-diffusion-model/requirements.txt
@@ -1,4 +1,4 @@
 streamlit==1.37.0
 boto3==1.28.0
-Pillow==10.3.0
+Pillow==12.1.0
 langchain==0.2.10

--- a/HR-Luminary-with-Amazon-Bedrock/pages/1_Read_Resume.py
+++ b/HR-Luminary-with-Amazon-Bedrock/pages/1_Read_Resume.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 import json
 
 # Constants and configurations
-CLAUDE_MODEL = "anthropic.claude-3-sonnet-20240229-v1:0"
+CLAUDE_MODEL = "anthropic.claude-sonnet-4-6"
 
 class BedrockClient:
     def __init__(self):

--- a/HR-Luminary-with-Amazon-Bedrock/requirements.txt
+++ b/HR-Luminary-with-Amazon-Bedrock/requirements.txt
@@ -1,5 +1,5 @@
 transformers
-Pillow
+Pillow>=12.1.0
 pypdf
 jq
 langchain==0.3.7

--- a/Location-Analysis-System-with-Amazon-Bedrock/Libs.py
+++ b/Location-Analysis-System-with-Amazon-Bedrock/Libs.py
@@ -31,7 +31,7 @@ def call_claude_sonet_stream(prompt):
 
     body = json.dumps(prompt_config)
 
-    modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
     accept = "application/json"
     contentType = "application/json"
 
@@ -112,7 +112,7 @@ def get_response_from_model(prompt_content, image_bytes):
     session = boto3.Session()
     bedrock = session.client(service_name='bedrock-runtime') #creates a Bedrock client
     body = init(prompt_content, image_bytes)    
-    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0", contentType="application/json", accept="application/json")
+    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-sonnet-4-6", contentType="application/json", accept="application/json")
         
     stream = response['body']
     if stream:

--- a/Location-Analysis-System-with-Amazon-Bedrock/check_in/check_in_lib.py
+++ b/Location-Analysis-System-with-Amazon-Bedrock/check_in/check_in_lib.py
@@ -151,7 +151,7 @@ def get_response_from_model(prompt_content=None, image_bytes=None, mask_prompt=N
     
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Location-Analysis-System-with-Amazon-Bedrock/check_uniform/check_uniform_lib.py
+++ b/Location-Analysis-System-with-Amazon-Bedrock/check_uniform/check_uniform_lib.py
@@ -99,7 +99,7 @@ def get_response_from_model(image_bytes):
     
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Location-Analysis-System-with-Amazon-Bedrock/content_moderation.1/content_moderation_lib.py
+++ b/Location-Analysis-System-with-Amazon-Bedrock/content_moderation.1/content_moderation_lib.py
@@ -84,7 +84,7 @@ def get_response_from_model(prompt_content, image_bytes):
     body = get_content_moderation_prompt(image_bytes)    
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Location-Analysis-System-with-Amazon-Bedrock/content_moderation/content_moderation_lib.py
+++ b/Location-Analysis-System-with-Amazon-Bedrock/content_moderation/content_moderation_lib.py
@@ -175,7 +175,7 @@ def analyze_frame(session, frame):
         body = get_content_moderation_prompt(frame)
         response = session.invoke_model_with_response_stream(
             body=body,
-            modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            modelId="anthropic.claude-sonnet-4-6",
             contentType="application/json",
             accept="application/json"
         )
@@ -228,7 +228,7 @@ def get_response_from_model(prompt_content, content_bytes, content_type="image")
             
             response = bedrock.invoke_model_with_response_stream(
                 body=body,
-                modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                modelId="anthropic.claude-sonnet-4-6",
                 contentType="application/json",
                 accept="application/json"
             )

--- a/Location-Analysis-System-with-Amazon-Bedrock/image_lib.py
+++ b/Location-Analysis-System-with-Amazon-Bedrock/image_lib.py
@@ -15,7 +15,7 @@ bedrock = session.client(
     endpoint_url=os.environ.get("BWB_ENDPOINT_URL")
 ) 
 
-bedrock_model_id = "stability.stable-diffusion-xl-v1" #use the Stable Diffusion model
+bedrock_model_id = "amazon.nova-canvas-v1:0" #use the Stable Diffusion model
 
 
 

--- a/Location-Analysis-System-with-Amazon-Bedrock/product_description/product_description_lib.py
+++ b/Location-Analysis-System-with-Amazon-Bedrock/product_description/product_description_lib.py
@@ -113,7 +113,7 @@ def get_response_from_model(prompt_content, image_bytes, prizm):
     body = get_product_description(prompt_content, image_bytes, prizm)    
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Location-Analysis-System-with-Amazon-Bedrock/requirements.txt
+++ b/Location-Analysis-System-with-Amazon-Bedrock/requirements.txt
@@ -10,7 +10,7 @@ torch
 
 # Image and Video Processing
 opencv-python-headless
-Pillow
+Pillow>=12.1.0
 numpy
 
 # Document processing

--- a/OCR-GenAI/claude3_boto3_ocr.py
+++ b/OCR-GenAI/claude3_boto3_ocr.py
@@ -9,7 +9,7 @@ import os
 import boto3
 
 
-MODEL_ID = os.environ.get('MODEL_ID', 'anthropic.claude-3-5-sonnet-20240620-v1:0')
+MODEL_ID = os.environ.get('MODEL_ID', 'anthropic.claude-sonnet-4-6')
 
 
 def build_chain():

--- a/OCR-GenAI/claude3_langchain_ocr.py
+++ b/OCR-GenAI/claude3_langchain_ocr.py
@@ -13,7 +13,7 @@ from langchain_core.outputs import ChatGenerationChunk
 class ClaudeOCRProcessor:
     """Handles OCR processing using Claude 3.5 Sonnet"""
     
-    DEFAULT_MODEL = 'anthropic.claude-3-sonnet-20240229-v1:0'
+    DEFAULT_MODEL = 'anthropic.claude-sonnet-4-6'
     
     def __init__(
         self,

--- a/Product-Description-Generator-with-Amazon-Bedrock/Libs.py
+++ b/Product-Description-Generator-with-Amazon-Bedrock/Libs.py
@@ -31,7 +31,7 @@ def call_claude_sonet_stream(prompt):
 
     body = json.dumps(prompt_config)
 
-    modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
     accept = "application/json"
     contentType = "application/json"
 
@@ -112,7 +112,7 @@ def get_response_from_model(prompt_content, image_bytes):
     session = boto3.Session()
     bedrock = session.client(service_name='bedrock-runtime') #creates a Bedrock client
     body = init(prompt_content, image_bytes)    
-    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0", contentType="application/json", accept="application/json")
+    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-sonnet-4-6", contentType="application/json", accept="application/json")
         
     stream = response['body']
     if stream:

--- a/Product-Description-Generator-with-Amazon-Bedrock/check_in/check_in_lib.py
+++ b/Product-Description-Generator-with-Amazon-Bedrock/check_in/check_in_lib.py
@@ -151,7 +151,7 @@ def get_response_from_model(prompt_content=None, image_bytes=None, mask_prompt=N
     
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Product-Description-Generator-with-Amazon-Bedrock/check_uniform/check_uniform_lib.py
+++ b/Product-Description-Generator-with-Amazon-Bedrock/check_uniform/check_uniform_lib.py
@@ -99,7 +99,7 @@ def get_response_from_model(image_bytes):
     
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Product-Description-Generator-with-Amazon-Bedrock/content_moderation.1/content_moderation_lib.py
+++ b/Product-Description-Generator-with-Amazon-Bedrock/content_moderation.1/content_moderation_lib.py
@@ -84,7 +84,7 @@ def get_response_from_model(prompt_content, image_bytes):
     body = get_content_moderation_prompt(image_bytes)    
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Product-Description-Generator-with-Amazon-Bedrock/content_moderation/content_moderation_lib.py
+++ b/Product-Description-Generator-with-Amazon-Bedrock/content_moderation/content_moderation_lib.py
@@ -175,7 +175,7 @@ def analyze_frame(session, frame):
         body = get_content_moderation_prompt(frame)
         response = session.invoke_model_with_response_stream(
             body=body,
-            modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            modelId="anthropic.claude-sonnet-4-6",
             contentType="application/json",
             accept="application/json"
         )
@@ -228,7 +228,7 @@ def get_response_from_model(prompt_content, content_bytes, content_type="image")
             
             response = bedrock.invoke_model_with_response_stream(
                 body=body,
-                modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                modelId="anthropic.claude-sonnet-4-6",
                 contentType="application/json",
                 accept="application/json"
             )

--- a/Product-Description-Generator-with-Amazon-Bedrock/image_lib.py
+++ b/Product-Description-Generator-with-Amazon-Bedrock/image_lib.py
@@ -15,7 +15,7 @@ bedrock = session.client(
     endpoint_url=os.environ.get("BWB_ENDPOINT_URL")
 ) 
 
-bedrock_model_id = "stability.stable-diffusion-xl-v1" #use the Stable Diffusion model
+bedrock_model_id = "amazon.nova-canvas-v1:0" #use the Stable Diffusion model
 
 
 

--- a/Product-Description-Generator-with-Amazon-Bedrock/product_description/product_description_lib.py
+++ b/Product-Description-Generator-with-Amazon-Bedrock/product_description/product_description_lib.py
@@ -113,7 +113,7 @@ def get_response_from_model(prompt_content, image_bytes, prizm):
     body = get_product_description(prompt_content, image_bytes, prizm)    
     response = bedrock.invoke_model_with_response_stream(
         body=body,
-        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         contentType="application/json",
         accept="application/json"
     )

--- a/Product-Description-Generator-with-Amazon-Bedrock/requirements.txt
+++ b/Product-Description-Generator-with-Amazon-Bedrock/requirements.txt
@@ -10,7 +10,7 @@ torch
 
 # Image and Video Processing
 opencv-python-headless
-Pillow
+Pillow>=12.1.0
 numpy
 
 # Document processing

--- a/TapVision-with-Amazon-Bedrock/Libs.py
+++ b/TapVision-with-Amazon-Bedrock/Libs.py
@@ -31,7 +31,7 @@ def call_claude_sonet_stream(prompt):
 
     body = json.dumps(prompt_config)
 
-    modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    modelId = "anthropic.claude-sonnet-4-6"
     accept = "application/json"
     contentType = "application/json"
 
@@ -112,7 +112,7 @@ def get_response_from_model(prompt_content, image_bytes):
     session = boto3.Session()
     bedrock = session.client(service_name='bedrock-runtime') #creates a Bedrock client
     body = init(prompt_content, image_bytes)    
-    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0", contentType="application/json", accept="application/json")
+    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-sonnet-4-6", contentType="application/json", accept="application/json")
         
     stream = response['body']
     if stream:

--- a/TapVision-with-Amazon-Bedrock/content_moderation/content_moderation_lib.py
+++ b/TapVision-with-Amazon-Bedrock/content_moderation/content_moderation_lib.py
@@ -41,7 +41,7 @@ def get_response_from_model(prompt_content, image_bytes):
     session = boto3.Session()
     bedrock = session.client(service_name='bedrock-runtime') #creates a Bedrock client
     body = get_product_description(prompt_content, image_bytes)    
-    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0", contentType="application/json", accept="application/json")
+    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-sonnet-4-6", contentType="application/json", accept="application/json")
         
     stream = response['body']
     if stream:

--- a/TapVision-with-Amazon-Bedrock/image_lib.py
+++ b/TapVision-with-Amazon-Bedrock/image_lib.py
@@ -15,7 +15,7 @@ bedrock = session.client(
     endpoint_url=os.environ.get("BWB_ENDPOINT_URL")
 ) 
 
-bedrock_model_id = "stability.stable-diffusion-xl-v1" #use the Stable Diffusion model
+bedrock_model_id = "amazon.nova-canvas-v1:0" #use the Stable Diffusion model
 
 
 

--- a/TapVision-with-Amazon-Bedrock/product_description/product_description_lib.py
+++ b/TapVision-with-Amazon-Bedrock/product_description/product_description_lib.py
@@ -71,7 +71,7 @@ def get_response_from_model(prompt_content, image_bytes, prizm):
     session = boto3.Session()
     bedrock = session.client(service_name='bedrock-runtime') #creates a Bedrock client
     body = get_product_description(prompt_content, image_bytes, prizm)    
-    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-3-5-sonnet-20240620-v1:0", contentType="application/json", accept="application/json")
+    response = bedrock.invoke_model_with_response_stream(body=body, modelId="anthropic.claude-sonnet-4-6", contentType="application/json", accept="application/json")
         
     stream = response['body']
     if stream:

--- a/TapVision-with-Amazon-Bedrock/requirements.txt
+++ b/TapVision-with-Amazon-Bedrock/requirements.txt
@@ -1,6 +1,6 @@
 faiss-cpu
 transformers==4.38.0
-Pillow
+Pillow>=12.1.0
 pypdf==3.17.0
 jq
 langchain==0.2.10

--- a/amazon-nova-samples/multimodal-understanding/sample-apps/02-bedrock-notebook-lm/requirements.txt
+++ b/amazon-nova-samples/multimodal-understanding/sample-apps/02-bedrock-notebook-lm/requirements.txt
@@ -26,7 +26,7 @@ fsspec==2024.9.0
 funcy==2.0
 gradio==5.5.0
 gradio_client==1.4.0
-granian==1.4.0
+granian==2.7.3
 h11==0.14.0
 httpcore==1.0.5
 httpx==0.27.2
@@ -57,7 +57,7 @@ openai==1.50.2
 orjson==3.10.7
 packaging==24.1
 pandas==2.2.3
-pillow==10.4.0
+pillow==12.1.0
 promptic==0.7.5
 psutil==5.9.8
 pydantic==2.9.2
@@ -68,7 +68,7 @@ pyparsing==3.1.4
 pypdf==4.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
-python-multipart==0.0.18
+python-multipart==0.0.26
 pytz==2024.2
 PyYAML==6.0.2
 referencing==0.35.1


### PR DESCRIPTION
…Python

Fixes three high severity security alerts:

1. granian (CVE - high severity)
   - amazon-nova-samples/.../02-bedrock-notebook-lm/requirements.txt
   - 1.4.0 -> 2.7.3 (latest stable)

2. python-multipart (CVE-2026-24486, CVE-2026-40347 - high severity)
   - amazon-nova-samples/.../02-bedrock-notebook-lm/requirements.txt
   - 0.0.18 -> 0.0.26 (path traversal + DoS fix)

3. GitPython (CVE-2022-24439, CVE-2023-40267 - high severity RCE)
   - GenAI-Model-Evaluator/requirements.txt
   - 3.1.40/3.1.42 -> 3.1.43 across all affected files
   - Also removed duplicate GitPython entry in AWS-GenAI-Code-Security-Review

Additional fixes included in this branch:
- Pillow upgraded to 12.1.0 (CVE-2026-42311)
- requests upgraded to 2.33.0 (CVE-2026-25645)
- urllib3 upgraded to 2.6.3 (CVE-2026-21441)
- cryptography upgraded to 46.0.5 (CVE-2026-26007)
- Legacy AI models migrated to Claude Sonnet 4.6 / Nova 2 Lite / Nova Canvas
- Security code fixes: path traversal, zip-slip, JSON stream error handling

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
