### PR TITLE
fix: replace hardcoded AWS regions with env variables

### DIFF
--- a/AWS-GenAI-Market-Sage/libs.py
+++ b/AWS-GenAI-Market-Sage/libs.py
@@ -1,3 +1,4 @@
+import os
 import boto3, json
 from dotenv import load_dotenv
 from langchain.retrievers.bedrock import AmazonKnowledgeBasesRetriever
@@ -132,7 +133,7 @@ def search(question, callback):
     # Truncate the question if it's too long
     max_query_length = 1000
     truncated_question = question[:max_query_length] if len(question) > max_query_length else question
-    bedrock_client = boto3.client('bedrock-runtime', region_name = 'us-east-1')
+    bedrock_client = boto3.client('bedrock-runtime', region_name=os.environ.get('AWS_REGION', 'us-east-1'))
 
     model_kwargs_claude = { "temperature": 0.5, "top_p": 1}
     llm = BedrockChat(

--- a/AWS-Stock-Agent-with-Bedrock/libs.py
+++ b/AWS-Stock-Agent-with-Bedrock/libs.py
@@ -1,3 +1,4 @@
+import os
 import boto3, json
 from dotenv import load_dotenv
 from langchain.retrievers.bedrock import AmazonKnowledgeBasesRetriever
@@ -132,7 +133,7 @@ def search(question, callback):
     # Truncate the question if it's too long
     max_query_length = 1000
     truncated_question = question[:max_query_length] if len(question) > max_query_length else question
-    bedrock_client = boto3.client('bedrock-runtime', region_name = 'us-east-1')
+    bedrock_client = boto3.client('bedrock-runtime', region_name=os.environ.get('AWS_REGION', 'us-east-1'))
 
     model_kwargs_claude = { "temperature": 0.5, "top_p": 1}
     llm = BedrockChat(

--- a/Amazon-Bedrock-Alt-Text-Generator/pdf_image_alt_text_generator/generator.py
+++ b/Amazon-Bedrock-Alt-Text-Generator/pdf_image_alt_text_generator/generator.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 import json
 from pydantic import BaseModel, Field
@@ -20,7 +21,7 @@ from uuid import uuid4
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-session = boto3.Session(region_name="us-east-1")
+session = boto3.Session(region_name=os.environ.get("AWS_REGION", "us-east-1"))
 
 MODEL_ID = "amazon.nova-2-lite-v1:0"
 

--- a/Generate-images-using-Amazon-Bedrock-with-stability-diffusion-model/app.py
+++ b/Generate-images-using-Amazon-Bedrock-with-stability-diffusion-model/app.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 import boto3
 import json
@@ -6,7 +7,7 @@ import io
 from PIL import Image
 
 # Initialize the Bedrock Runtime client
-client = boto3.client('bedrock-runtime', region_name='us-west-2')
+client = boto3.client('bedrock-runtime', region_name=os.environ.get('AWS_REGION', 'us-west-2'))
 
 # Set page configuration for a professional look
 st.set_page_config(

--- a/Generate-images-using-Amazon-Bedrock-with-stability-diffusion-model/prompt/app-prompt.py
+++ b/Generate-images-using-Amazon-Bedrock-with-stability-diffusion-model/prompt/app-prompt.py
@@ -1,9 +1,10 @@
+import os
 import streamlit as st
 import boto3
 from botocore.exceptions import ClientError
 
 # Initialize AWS Bedrock client
-client = boto3.client("bedrock-runtime", region_name="us-west-2")
+client = boto3.client("bedrock-runtime", region_name=os.environ.get("AWS_REGION", "us-west-2"))
 
 # Define Claude 3 Sonnet model ID
 model_id = "anthropic.claude-sonnet-4-6"


### PR DESCRIPTION
Use os.environ.get('AWS_REGION', default) for portability across regions.