### PR TITLE
fix: add S3 encryption + remove hardcoded account IDs

### DIFF
--- a/AWS-GenAI-Contact-Center/amazon-connect/contact_flow/prsv-aws-connect-flow.json
+++ b/AWS-GenAI-Contact-Center/amazon-connect/contact_flow/prsv-aws-connect-flow.json
@@ -384,7 +384,7 @@
     },
     {
       "Parameters": {
-        "LambdaFunctionARN": "arn:aws:lambda:us-west-2:884189903498:function:dev-connectvoice-start-streaming",
+        "LambdaFunctionARN": "arn:aws:lambda:us-west-2:<YOUR_ACCOUNT_ID>:function:dev-connectvoice-start-streaming",
         "InvocationTimeLimitSeconds": "7",
         "LambdaInvocationAttributes": {
           "kvsStreamArn": "$.MediaStreams.Customer.Audio.StreamARN",
@@ -650,7 +650,7 @@
     },
     {
       "Parameters": {
-        "LambdaFunctionARN": "arn:aws:lambda:us-west-2:884189903498:function:dev-connectvoice-virtual-agent",
+        "LambdaFunctionARN": "arn:aws:lambda:us-west-2:<YOUR_ACCOUNT_ID>:function:dev-connectvoice-virtual-agent",
         "InvocationTimeLimitSeconds": "7",
         "ResponseValidation": {
           "ResponseType": "STRING_MAP"

--- a/amazon-nova-samples/multimodal-generation/video-generation/python/01_text_to_video_generation.py
+++ b/amazon-nova-samples/multimodal-generation/video-generation/python/01_text_to_video_generation.py
@@ -31,8 +31,21 @@ def generate_video(s3_destination_bucket, video_prompt, model_id=DEFAULT_MODEL_I
     # Set up the S3 client
     s3_client = boto3.client("s3")
 
-    # Create the S3 bucket
+    # Create the S3 bucket with encryption and public access block
     s3_client.create_bucket(Bucket=s3_destination_bucket)
+    s3_client.put_bucket_encryption(
+        Bucket=s3_destination_bucket,
+        ServerSideEncryptionConfiguration={
+            'Rules': [{'ApplyServerSideEncryptionByDefault': {'SSEAlgorithm': 'AES256'}}]
+        }
+    )
+    s3_client.put_public_access_block(
+        Bucket=s3_destination_bucket,
+        PublicAccessBlockConfiguration={
+            'BlockPublicAcls': True, 'IgnorePublicAcls': True,
+            'BlockPublicPolicy': True, 'RestrictPublicBuckets': True
+        }
+    )
 
     # Create the Bedrock Runtime client
     bedrock_runtime = boto3.client("bedrock-runtime")

--- a/amazon-nova-samples/multimodal-generation/video-generation/python/02_image_to_video_generation.py
+++ b/amazon-nova-samples/multimodal-generation/video-generation/python/02_image_to_video_generation.py
@@ -31,8 +31,21 @@ def generate_video(s3_destination_bucket, input_image_path, video_prompt, model_
     # Set up the S3 client
     s3_client = boto3.client("s3")
 
-    # Create the S3 bucket
+    # Create the S3 bucket with encryption and public access block
     s3_client.create_bucket(Bucket=s3_destination_bucket)
+    s3_client.put_bucket_encryption(
+        Bucket=s3_destination_bucket,
+        ServerSideEncryptionConfiguration={
+            'Rules': [{'ApplyServerSideEncryptionByDefault': {'SSEAlgorithm': 'AES256'}}]
+        }
+    )
+    s3_client.put_public_access_block(
+        Bucket=s3_destination_bucket,
+        PublicAccessBlockConfiguration={
+            'BlockPublicAcls': True, 'IgnorePublicAcls': True,
+            'BlockPublicPolicy': True, 'RestrictPublicBuckets': True
+        }
+    )
 
     # Create the Bedrock Runtime client
     bedrock_runtime = boto3.client("bedrock-runtime")

--- a/amazon-nova-samples/multimodal-generation/video-generation/python/03_chaining_video_generations.py
+++ b/amazon-nova-samples/multimodal-generation/video-generation/python/03_chaining_video_generations.py
@@ -34,8 +34,21 @@ def generate_video(s3_destination_bucket, video_prompt, input_image_path=None, m
     # Set up the S3 client
     s3_client = boto3.client("s3")
 
-    # Create the S3 bucket
+    # Create the S3 bucket with encryption and public access block
     s3_client.create_bucket(Bucket=s3_destination_bucket)
+    s3_client.put_bucket_encryption(
+        Bucket=s3_destination_bucket,
+        ServerSideEncryptionConfiguration={
+            'Rules': [{'ApplyServerSideEncryptionByDefault': {'SSEAlgorithm': 'AES256'}}]
+        }
+    )
+    s3_client.put_public_access_block(
+        Bucket=s3_destination_bucket,
+        PublicAccessBlockConfiguration={
+            'BlockPublicAcls': True, 'IgnorePublicAcls': True,
+            'BlockPublicPolicy': True, 'RestrictPublicBuckets': True
+        }
+    )
 
     # Create the Bedrock Runtime client
     bedrock_runtime = boto3.client("bedrock-runtime")


### PR DESCRIPTION
Add encryption/public-access-block to Nova S3 buckets. Remove hardcoded AWS account IDs from committed files.