### PR TITLE
refactor: migrate 17 new projects to shared requirements layers

### DIFF
--- a/AWS-Agent-Evaluator/requirements.txt
+++ b/AWS-Agent-Evaluator/requirements.txt
@@ -1,3 +1,1 @@
-strands-agents>=0.3.0
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/strands.txt

--- a/AWS-Agentic-Assistant-with-Strands/requirements.txt
+++ b/AWS-Agentic-Assistant-with-Strands/requirements.txt
@@ -1,5 +1,1 @@
-strands-agents>=0.3.0
-strands-agents-tools>=0.1.0
-mcp>=1.0.0
-streamlit>=1.30.0
-boto3>=1.35.0
+-r ../requirements/strands.txt

--- a/AWS-Bedrock-Guardrails-Demo/requirements.txt
+++ b/AWS-Bedrock-Guardrails-Demo/requirements.txt
@@ -1,2 +1,1 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt

--- a/AWS-Chatbot-with-Long-Term-Memory/app.py
+++ b/AWS-Chatbot-with-Long-Term-Memory/app.py
@@ -3,7 +3,7 @@ import boto3
 from memory import save_message, get_history, summarize_history
 
 bedrock = boto3.client("bedrock-runtime")
-MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0"
+MODEL_ID = "anthropic.claude-sonnet-4-6"
 
 st.set_page_config(page_title="Chatbot with Memory", page_icon="🧠")
 st.title("🧠 Chatbot with Long-Term Memory")

--- a/AWS-Chatbot-with-Long-Term-Memory/memory.py
+++ b/AWS-Chatbot-with-Long-Term-Memory/memory.py
@@ -31,7 +31,7 @@ def summarize_history(user_id):
         return "No conversation history yet."
     transcript = "\n".join(f"{m['role']}: {m['content'][0]['text']}" for m in history)
     resp = bedrock.converse(
-        modelId="anthropic.claude-3-haiku-20240307-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         messages=[{"role": "user", "content": [{"text": f"Summarize this conversation in 2-3 sentences:\n{transcript}"}]}],
     )
     return resp["output"]["message"]["content"][0]["text"]

--- a/AWS-Chatbot-with-Long-Term-Memory/requirements.txt
+++ b/AWS-Chatbot-with-Long-Term-Memory/requirements.txt
@@ -1,2 +1,1 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt

--- a/AWS-Document-Comparison-with-Bedrock/comparator.py
+++ b/AWS-Document-Comparison-with-Bedrock/comparator.py
@@ -8,7 +8,7 @@ def extract_text(pdf_file):
     return "\n".join(page.extract_text() or "" for page in reader.pages)
 
 
-def compare_documents(text1, text2, model_id="anthropic.claude-3-sonnet-20240229-v1:0"):
+def compare_documents(text1, text2, model_id="anthropic.claude-sonnet-4-6"):
     """Compare two documents using Bedrock Converse API and return structured differences."""
     client = boto3.client("bedrock-runtime")
     prompt = (

--- a/AWS-Document-Comparison-with-Bedrock/requirements.txt
+++ b/AWS-Document-Comparison-with-Bedrock/requirements.txt
@@ -1,3 +1,4 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/langchain.txt
+
+# Project-specific
 pypdf>=4.0.0

--- a/AWS-GenAI-Cost-Optimizer/requirements.txt
+++ b/AWS-GenAI-Cost-Optimizer/requirements.txt
@@ -1,3 +1,4 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt
+
+# Project-specific — data analysis
 pandas>=2.0.0

--- a/AWS-GenAI-Data-Analyst/app.py
+++ b/AWS-GenAI-Data-Analyst/app.py
@@ -41,7 +41,7 @@ if uploaded_file:
         )
 
         response = bedrock.converse(
-            modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+            modelId="anthropic.claude-sonnet-4-6",
             messages=[{"role": "user", "content": [{"text": prompt}]}],
             inferenceConfig={"maxTokens": 1024, "temperature": 0.1},
         )

--- a/AWS-GenAI-Data-Analyst/requirements.txt
+++ b/AWS-GenAI-Data-Analyst/requirements.txt
@@ -1,4 +1,5 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt
+
+# Project-specific — data analysis & visualization
 pandas>=2.0.0
 matplotlib>=3.7.0

--- a/AWS-GenAI-Observability-Dashboard/requirements.txt
+++ b/AWS-GenAI-Observability-Dashboard/requirements.txt
@@ -1,5 +1,6 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt
+
+# Project-specific — observability & metrics
 pandas>=2.0.0
 plotly>=5.0.0
 numpy>=1.24.0

--- a/AWS-GraphRAG-Knowledge-System/graph_builder.py
+++ b/AWS-GraphRAG-Knowledge-System/graph_builder.py
@@ -3,7 +3,7 @@ import boto3
 import networkx as nx
 
 bedrock = boto3.client("bedrock-runtime", region_name="us-east-1")
-MODEL_ID = "anthropic.claude-3-sonnet-20240229-v1:0"
+MODEL_ID = "anthropic.claude-sonnet-4-6"
 
 
 def converse(prompt):

--- a/AWS-GraphRAG-Knowledge-System/requirements.txt
+++ b/AWS-GraphRAG-Knowledge-System/requirements.txt
@@ -1,4 +1,5 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/langchain.txt
+
+# Project-specific — graph visualization
 networkx>=3.0
 pyvis>=0.3.0

--- a/AWS-Infrastructure-Analyzer-with-Bedrock/analyzer.py
+++ b/AWS-Infrastructure-Analyzer-with-Bedrock/analyzer.py
@@ -11,7 +11,7 @@ def analyze_template(template_content: str, filename: str) -> list:
     """Analyze an infrastructure template using Amazon Bedrock Converse API."""
     client = boto3.client("bedrock-runtime")
     response = client.converse(
-        modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+        modelId="anthropic.claude-sonnet-4-6",
         system=[{"text": SYSTEM_PROMPT}],
         messages=[
             {

--- a/AWS-Infrastructure-Analyzer-with-Bedrock/requirements.txt
+++ b/AWS-Infrastructure-Analyzer-with-Bedrock/requirements.txt
@@ -1,2 +1,1 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt

--- a/AWS-Meeting-Summarizer-with-Bedrock/app.py
+++ b/AWS-Meeting-Summarizer-with-Bedrock/app.py
@@ -61,7 +61,7 @@ Transcript:
 
         with st.spinner("Summarizing with Bedrock..."):
             response = bedrock.converse(
-                modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+                modelId="anthropic.claude-sonnet-4-6",
                 messages=[{"role": "user", "content": [{"text": prompt}]}],
             )
             summary = response["output"]["message"]["content"][0]["text"]

--- a/AWS-Meeting-Summarizer-with-Bedrock/requirements.txt
+++ b/AWS-Meeting-Summarizer-with-Bedrock/requirements.txt
@@ -1,2 +1,1 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt

--- a/AWS-Multi-Agent-Workflow/requirements.txt
+++ b/AWS-Multi-Agent-Workflow/requirements.txt
@@ -1,3 +1,1 @@
-strands-agents>=0.3.0
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/strands.txt

--- a/AWS-Multimodal-RAG-with-Bedrock/app.py
+++ b/AWS-Multimodal-RAG-with-Bedrock/app.py
@@ -23,7 +23,7 @@ def init_config() -> RAGConfig:
         region = st.text_input("AWS Region", value=os.environ.get("AWS_REGION", "us-east-1"))
         kb_id = st.text_input("Knowledge Base ID", value=os.environ.get("BEDROCK_KB_ID", ""))
         s3_bucket = st.text_input("S3 Bucket", value=os.environ.get("S3_BUCKET", ""))
-        model_id = st.text_input("Model ID", value=os.environ.get("MODEL_ID", "anthropic.claude-3-sonnet-20240229-v1:0"))
+        model_id = st.text_input("Model ID", value=os.environ.get("MODEL_ID", "anthropic.claude-sonnet-4-6"))
     return RAGConfig(region=region, kb_id=kb_id, s3_bucket=s3_bucket, model_id=model_id)
 
 

--- a/AWS-Multimodal-RAG-with-Bedrock/rag_engine.py
+++ b/AWS-Multimodal-RAG-with-Bedrock/rag_engine.py
@@ -10,7 +10,7 @@ class RAGConfig:
     region: str = os.environ.get("AWS_REGION", "us-east-1")
     kb_id: str = os.environ.get("BEDROCK_KB_ID", "")
     s3_bucket: str = os.environ.get("S3_BUCKET", "")
-    model_id: str = os.environ.get("MODEL_ID", "anthropic.claude-3-sonnet-20240229-v1:0")
+    model_id: str = os.environ.get("MODEL_ID", "anthropic.claude-sonnet-4-6")
 
 
 def index_document(file_bytes: bytes, file_name: str, config: RAGConfig) -> str:

--- a/AWS-Multimodal-RAG-with-Bedrock/requirements.txt
+++ b/AWS-Multimodal-RAG-with-Bedrock/requirements.txt
@@ -1,3 +1,4 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/langchain.txt
+
+# Project-specific
 pypdf>=4.0.0

--- a/AWS-Nova-Model-Distillation/requirements.txt
+++ b/AWS-Nova-Model-Distillation/requirements.txt
@@ -1,2 +1,1 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt

--- a/AWS-Prompt-Engineering-Toolkit/requirements.txt
+++ b/AWS-Prompt-Engineering-Toolkit/requirements.txt
@@ -1,3 +1,4 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt
+
+# Project-specific
 pandas>=2.0.0

--- a/AWS-Smart-Email-Assistant/app.py
+++ b/AWS-Smart-Email-Assistant/app.py
@@ -31,7 +31,7 @@ if st.button("Process", type="primary"):
         with st.spinner("Processing..."):
             try:
                 response = bedrock.converse(
-                    modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+                    modelId="anthropic.claude-sonnet-4-6",
                     messages=[{"role": "user", "content": [{"text": user_msg}]}],
                     system=[{"text": SYSTEM_PROMPTS[action]}],
                     inferenceConfig={"maxTokens": 1024, "temperature": 0.3},

--- a/AWS-Smart-Email-Assistant/requirements.txt
+++ b/AWS-Smart-Email-Assistant/requirements.txt
@@ -1,2 +1,1 @@
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/base.txt

--- a/AWS-Voice-Agent-with-Nova-Sonic/requirements.txt
+++ b/AWS-Voice-Agent-with-Nova-Sonic/requirements.txt
@@ -1,5 +1,5 @@
-strands-agents>=0.3.0
-boto3>=1.35.0
-streamlit>=1.30.0
+-r ../requirements/strands.txt
+
+# Project-specific — audio I/O
 sounddevice>=0.4.6
 numpy>=1.24.0

--- a/requirements/strands.txt
+++ b/requirements/strands.txt
@@ -1,0 +1,13 @@
+# =============================================================================
+# strands.txt — AWS Strands Agents stack
+#
+# Usage:
+#   -r ../requirements/strands.txt
+# =============================================================================
+
+-r base.txt
+
+# Strands Agents framework
+strands-agents>=0.3.0
+strands-agents-tools>=0.1.0
+mcp>=1.0.0

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -199,6 +199,9 @@ ALLOWED_LEGACY_FILES = {
     "Generate-images-using-Amazon-Bedrock-with-stability-diffusion-model/app.py",
     # Nova samples reference their own models
     "amazon-nova-samples/multimodal-understanding/sample-apps/01-multimodal-with-helper-libraries/mm_understanding.py",
+    # Prompt toolkit and Guardrails demo show model selection lists — legacy IDs intentional
+    "AWS-Prompt-Engineering-Toolkit/app.py",
+    "AWS-Bedrock-Guardrails-Demo/app.py",
 }
 
 


### PR DESCRIPTION
All new projects added in the latest batch were using standalone requirements.txt with range specifiers (>=). Migrated to shared layers:

  base.txt (boto3 + streamlit):
    - AWS-Bedrock-Guardrails-Demo
    - AWS-Chatbot-with-Long-Term-Memory
    - AWS-Infrastructure-Analyzer-with-Bedrock
    - AWS-Meeting-Summarizer-with-Bedrock
    - AWS-Nova-Model-Distillation
    - AWS-Smart-Email-Assistant

  langchain.txt:
    - AWS-Document-Comparison-with-Bedrock
    - AWS-Multimodal-RAG-with-Bedrock
    - AWS-GraphRAG-Knowledge-System

  base.txt + data packages:
    - AWS-GenAI-Cost-Optimizer (+ pandas)
    - AWS-GenAI-Data-Analyst (+ pandas, matplotlib)
    - AWS-GenAI-Observability-Dashboard (+ pandas, plotly, numpy)
    - AWS-Prompt-Engineering-Toolkit (+ pandas)

  New strands.txt layer (strands-agents + mcp):
    - AWS-Agent-Evaluator
    - AWS-Agentic-Assistant-with-Strands
    - AWS-Multi-Agent-Workflow
    - AWS-Voice-Agent-with-Nova-Sonic (+ sounddevice, numpy)

Also migrate legacy model IDs to anthropic.claude-sonnet-4-6 in 10 files. AWS-Prompt-Engineering-Toolkit and AWS-Bedrock-Guardrails-Demo kept as ALLOWED_LEGACY_FILES (intentional model selection lists).

448 tests pass.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
