### PR TITLE
fix: migrate langchain deps to shared requirements

### DIFF
--- a/Amazon-Bedrock-Model-Evaluator/requirements.txt
+++ b/Amazon-Bedrock-Model-Evaluator/requirements.txt
@@ -1,6 +1,6 @@
--r ../requirements/base.txt
+-r ../requirements/langchain.txt
 
-# Project-specific (fully pinned lockfile for reproducibility)
+# Project-specific
 aioboto3==13.0.1
 aiobotocore==2.13.0
 aiofiles==23.2.1
@@ -17,10 +17,7 @@ asyncio==3.4.3
 attrs==23.2.0
 beautifulsoup4==4.12.3
 blinker==1.7.0
-boto3==1.34.106
-botocore==1.34.106
 cachetools==5.3.3
-certifi==2024.7.4
 cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
@@ -54,12 +51,6 @@ jsonpointer==3.0.0
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
 kiwisolver==1.4.5
-langchain==0.3.30
-langchain-aws==0.1.5
-langchain-community==0.3.22
-langchain-core>=0.2.20,<0.3.0
-langchain-openai==0.1.8
-langchain-text-splitters==0.2.1
 langsmith==0.8.0
 lxml==5.2.1
 Markdown==3.6
@@ -80,10 +71,8 @@ orjson==3.10.5
 packaging==24.0
 palettable==3.3.3
 pandas==2.2.1
-pillow==12.1.0
 pip==23.3
 prometheus_client==0.20.0
-protobuf==5.29.4
 pyarrow==15.0.2
 pyarrow-hotfix==0.6
 pycparser==2.22
@@ -93,27 +82,21 @@ pydeck==0.8.1b0
 Pygments==2.17.2
 pymdown-extensions==10.7.1
 pyparsing==3.1.2
-pypdf==4.2.0
 pysbd==0.3.4
 python-dateutil==2.9.0.post0
-python-dotenv==1.0.1
 pytz==2024.1
 PyYAML==6.0.1
 ragas==0.1.9
 referencing==0.34.0
 regex==2024.5.15
-requests==2.32.3
 rich==13.7.1
 rpds-py==0.18.0
-s3transfer==0.10.1
-setuptools==78.1.1
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1
 soupsieve==2.5
 SQLAlchemy==2.0.30
 st-annotated-text==4.0.1
-streamlit==1.33.0
 streamlit-camera-input-live==0.2.0
 streamlit-card==1.0.0
 streamlit-embedcode==0.1.2
@@ -132,7 +115,6 @@ tqdm==4.66.4
 typing-inspect==0.9.0
 typing_extensions==4.11.0
 tzdata==2024.1
-urllib3==2.7.0
 validators==0.28.0
 wheel==0.41.2
 wrapt==1.16.0

--- a/GenAI-Model-Evaluator/requirements.txt
+++ b/GenAI-Model-Evaluator/requirements.txt
@@ -1,6 +1,6 @@
--r ../requirements/base.txt
+-r ../requirements/langchain.txt
 
-# Project-specific (fully pinned lockfile for reproducibility)
+# Project-specific
 aioboto3==13.0.1
 aiobotocore==2.13.0
 aiofiles==23.2.1
@@ -17,10 +17,7 @@ asyncio==3.4.3
 attrs==23.2.0
 beautifulsoup4==4.12.3
 blinker==1.7.0
-boto3==1.34.106
-botocore==1.34.106
 cachetools==5.3.3
-certifi==2024.7.4
 cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
@@ -54,12 +51,6 @@ jsonpointer==3.0.0
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
 kiwisolver==1.4.5
-langchain==0.2.9
-langchain-aws==0.1.5
-langchain-community==0.3.22
-langchain-core>=0.2.20,<0.3.0
-langchain-openai==0.1.8
-langchain-text-splitters==0.2.1
 langsmith==0.8.0
 lxml==5.2.1
 Markdown==3.6
@@ -80,10 +71,8 @@ orjson==3.10.5
 packaging==24.0
 palettable==3.3.3
 pandas==2.2.1
-pillow==12.1.0
 pip==23.3
 prometheus_client==0.20.0
-protobuf==5.29.4
 pyarrow==15.0.2
 pyarrow-hotfix==0.6
 pycparser==2.22
@@ -93,27 +82,21 @@ pydeck==0.8.1b0
 Pygments==2.17.2
 pymdown-extensions==10.7.1
 pyparsing==3.1.2
-pypdf==4.2.0
 pysbd==0.3.4
 python-dateutil==2.9.0.post0
-python-dotenv==1.0.1
 pytz==2024.1
 PyYAML==6.0.1
 ragas==0.1.9
 referencing==0.34.0
 regex==2024.5.15
-requests==2.32.3
 rich==13.7.1
 rpds-py==0.18.0
-s3transfer==0.10.1
-setuptools==78.1.1
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1
 soupsieve==2.5
 SQLAlchemy==2.0.30
 st-annotated-text==4.0.1
-streamlit==1.33.0
 streamlit-camera-input-live==0.2.0
 streamlit-card==1.0.0
 streamlit-embedcode==0.1.2
@@ -132,7 +115,6 @@ tqdm==4.66.4
 typing-inspect==0.9.0
 typing_extensions==4.11.0
 tzdata==2024.1
-urllib3==2.7.0
 validators==0.28.0
 wheel==0.41.2
 wrapt==1.16.0


### PR DESCRIPTION
Amazon-Bedrock-Model-Evaluator and GenAI-Model-Evaluator were pinning langchain manually (with stale versions) instead of using the shared requirements/langchain.txt.

- Replace -r base.txt with -r langchain.txt
- Remove 6 direct langchain pins (langchain, langchain-aws, langchain-community, langchain-core, langchain-openai, langchain-text-splitters)
- Remove packages already covered by shared (boto3, streamlit, Pillow, requests, urllib3, protobuf, setuptools, pypdf, etc.)

GenAI-Model-Evaluator was on langchain==0.2.9; now aligned to langchain==0.3.30 via shared.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
