### PR TITLE
refactor: dedupe project requirements against shared files

### DIFF
--- a/AWS-Document-Comparison-with-Bedrock/requirements.txt
+++ b/AWS-Document-Comparison-with-Bedrock/requirements.txt
@@ -1,4 +1,1 @@
 -r ../requirements/langchain.txt
-
-# Project-specific
-pypdf>=4.0.0

--- a/AWS-Educational-Assistant/requirements.txt
+++ b/AWS-Educational-Assistant/requirements.txt
@@ -3,6 +3,5 @@
 # Project-specific
 transformers==4.53.0
 bs4==0.0.2
-setuptools==78.1.1
 pandas-datareader==0.10.0
 jq==1.8.0

--- a/AWS-GenAI-Code-Security-Review/requirements.txt
+++ b/AWS-GenAI-Code-Security-Review/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements/base.txt
 
-# Project-specific (fully pinned lockfile for reproducibility)
+# Project-specific
 aiohttp==3.14.0
 aiosignal==1.3.1
 altair==5.1.2
@@ -8,7 +8,6 @@ async-timeout==4.0.3
 attrs==23.1.0
 blinker==1.6.3
 cachetools==5.3.1
-certifi==2024.8.30
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
@@ -28,21 +27,16 @@ numpy==1.26.4
 openai==1.57.0
 packaging==24.0
 pandas==2.2.1
-Pillow==12.1.0
-protobuf==5.29.4
 pyarrow==23.0.1
 pydeck==0.9.1
 Pygments==2.18.0
 python-dateutil==2.9.0.post0
-python-dotenv==1.0.1
 pytz==2024.1
 referencing==0.35.1
-requests==2.32.3
 rich==13.9.4
 rpds-py==0.22.3
 six==1.17.0
 smmap==5.0.1
-streamlit==1.41.1
 tenacity==9.0.0
 toml==0.10.2
 toolz==1.0.0
@@ -51,11 +45,7 @@ tqdm==4.67.1
 typing_extensions==4.12.2
 tzdata==2024.2
 tzlocal==5.2
-urllib3==2.7.0
 validators==0.34.0
 watchdog==6.0.0
 yarl==1.18.3
 zipp==3.21.0
-boto3==1.35.58
-botocore==1.35.58
-GitPython==3.1.43

--- a/AWS-GenAI-Market-Sage/requirements.txt
+++ b/AWS-GenAI-Market-Sage/requirements.txt
@@ -14,4 +14,3 @@ anthropic==0.40.0
 vnstock3==0.3.0.6
 seaborn==0.13.2
 transformers==4.53.0
-s3transfer>=0.10.0,<0.11.0

--- a/AWS-Multimodal-RAG-with-Bedrock/requirements.txt
+++ b/AWS-Multimodal-RAG-with-Bedrock/requirements.txt
@@ -1,4 +1,1 @@
 -r ../requirements/langchain.txt
-
-# Project-specific
-pypdf>=4.0.0

--- a/Amazon-Bedrock-Claude3-Image-Analysis/requirements.txt
+++ b/Amazon-Bedrock-Claude3-Image-Analysis/requirements.txt
@@ -1,13 +1,10 @@
 -r ../requirements/base.txt
 
-# Project-specific (fully pinned lockfile for reproducibility)
+# Project-specific
 altair==5.2.0
 attrs==23.2.0
 blinker==1.7.0
-boto3==1.35.58
-botocore==1.35.58
 cachetools==5.3.3
-certifi==2024.7.4
 charset-normalizer==3.3.2
 click==8.1.7
 gitdb==4.0.11
@@ -24,24 +21,17 @@ mdurl==0.1.2
 numpy==1.26.4
 packaging==23.2
 pandas==2.2.1
-pillow==12.1.0
 pip==24.3.1
-protobuf==5.29.4
 pyarrow==23.0.1
 pydeck==0.9.1
 Pygments==2.18.0
 python-dateutil==2.9.0.post0
-python-dotenv==1.0.1
 pytz==2024.2
 referencing==0.35.1
-requests==2.32.3
 rich==13.9.4
 rpds-py==0.22.3
-s3transfer==0.10.4
-setuptools==78.1.1
 six==1.17.0
 smmap==5.0.1
-streamlit==1.41.1
 tenacity==9.0.0
 toml==0.10.2
 toolz==1.0.0
@@ -49,7 +39,6 @@ tornado==6.4.2
 typing_extensions==4.12.2
 tzdata==2024.2
 tzlocal==5.2
-urllib3==2.7.0
 validators==0.34.0
 wheel==0.45.1
 zipp==3.21.0

--- a/CV-Maestro-Elevate-Your-Career-Narrative-with-Amazon-Bedrock/requirements.txt
+++ b/CV-Maestro-Elevate-Your-Career-Narrative-with-Amazon-Bedrock/requirements.txt
@@ -3,7 +3,6 @@
 # Project-specific
 transformers==4.53.0
 bs4==0.0.2
-setuptools==78.1.1
 pandas-datareader==0.10.0
 jq==1.8.0
 google-search-results==2.4.2

--- a/HR-Luminary-with-Amazon-Bedrock/requirements.txt
+++ b/HR-Luminary-with-Amazon-Bedrock/requirements.txt
@@ -3,7 +3,6 @@
 # Project-specific
 transformers==4.53.0
 bs4==0.0.2
-setuptools==78.1.1
 pandas-datareader==0.10.0
 jq==1.8.0
 google-search-results==2.4.2


### PR DESCRIPTION
Several projects re-pinned packages already provided by the shared requirements/ files, often with stale/conflicting versions. This removes that duplication so shared files are the single source of truth.

- Amazon-Bedrock-Claude3-Image-Analysis: drop boto3, botocore, s3transfer, streamlit, pillow, certifi, protobuf, python-dotenv, requests, urllib3, setuptools (all in base.txt)
- AWS-GenAI-Code-Security-Review: same base.txt dups + duplicate GitPython entry
- AWS-Document-Comparison, AWS-Multimodal-RAG: drop pypdf (in langchain.txt)
- AWS-Educational-Assistant, CV-Maestro, HR-Luminary: drop setuptools
- AWS-GenAI-Market-Sage: drop s3transfer

whisper/src kept standalone (nested sub-project, no shared overlap).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
