### PR TITLE
fix: bump tornado to 6.5.7 and aiohttp to 3.14.1 (CVE)

### DIFF
--- a/AWS-GenAI-Code-Security-Review/requirements.txt
+++ b/AWS-GenAI-Code-Security-Review/requirements.txt
@@ -1,7 +1,7 @@
 -r ../requirements/base.txt
 
 # Project-specific
-aiohttp==3.14.0
+aiohttp==3.14.1
 aiosignal==1.3.1
 altair==5.1.2
 async-timeout==4.0.3
@@ -40,7 +40,7 @@ smmap==5.0.1
 tenacity==9.0.0
 toml==0.10.2
 toolz==1.0.0
-tornado==6.4.2
+tornado==6.5.7
 tqdm==4.67.1
 typing_extensions==4.12.2
 tzdata==2024.2

--- a/Amazon-Bedrock-Claude3-Image-Analysis/requirements.txt
+++ b/Amazon-Bedrock-Claude3-Image-Analysis/requirements.txt
@@ -35,7 +35,7 @@ smmap==5.0.1
 tenacity==9.0.0
 toml==0.10.2
 toolz==1.0.0
-tornado==6.4.2
+tornado==6.5.7
 typing_extensions==4.12.2
 tzdata==2024.2
 tzlocal==5.2

--- a/Amazon-Bedrock-Model-Evaluator/requirements.txt
+++ b/Amazon-Bedrock-Model-Evaluator/requirements.txt
@@ -110,7 +110,7 @@ tenacity==8.2.3
 tiktoken==0.7.0
 toml==0.10.2
 toolz==0.12.1
-tornado==6.4.2
+tornado==6.5.7
 tqdm==4.66.4
 typing-inspect==0.9.0
 typing_extensions==4.11.0

--- a/GenAI-Model-Evaluator/requirements.txt
+++ b/GenAI-Model-Evaluator/requirements.txt
@@ -4,7 +4,7 @@
 aioboto3==13.0.1
 aiobotocore==2.13.0
 aiofiles==23.2.1
-aiohttp==3.14.0
+aiohttp==3.14.1
 aioitertools==0.11.0
 aiosignal==1.3.1
 altair==5.3.0
@@ -110,7 +110,7 @@ tenacity==8.2.3
 tiktoken==0.7.0
 toml==0.10.2
 toolz==0.12.1
-tornado==6.4.2
+tornado==6.5.7
 tqdm==4.66.4
 typing-inspect==0.9.0
 typing_extensions==4.11.0


### PR DESCRIPTION
Apply the security bumps from the stale Dependabot PRs directly onto the refactored main, avoiding the duplicate-package noise those PRs would have re-introduced (they were based on pre-refactor main).

- tornado 6.4.2 -> 6.5.7: Amazon-Bedrock-Claude3-Image-Analysis, Amazon-Bedrock-Model-Evaluator, AWS-GenAI-Code-Security-Review, GenAI-Model-Evaluator
- aiohttp 3.14.0 -> 3.14.1: AWS-GenAI-Code-Security-Review, GenAI-Model-Evaluator

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
